### PR TITLE
Update npm and minsdkversion for mabs 6.3 and 7 compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
             <access origin="https://api.facebook.com" />
             <access origin="https://*.fbcdn.net" />
             <access origin="https://*.akamaihd.net" />
-            <preference name="android-minSdkVersion" value="21" />
+            <preference name="android-minSdkVersion" value="23" />
         </config-file>
 
         <source-file src="src/android/facebookconnect.xml" target-dir="res/values" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,6 +19,9 @@
     <preference name="APP_ID" />
     <preference name="APP_NAME" />
 
+
+    <hook type="before_plugin_install" src="scripts/dependencyInstaller.js"/>
+
     <engines>
         <!-- Requires > 3.5.0 because of the custom Framework tag for iOS [CB-6698] -->
         <!-- Requires > 4.0.0 because of the Framework tag for Android that uses gradle -->

--- a/scripts/dependencyInstaller.js
+++ b/scripts/dependencyInstaller.js
@@ -1,0 +1,15 @@
+console.log("Running hook to install hooks pre-requisites");
+module.exports = function (context) {
+  return new Promise((resolve, reject) => {
+    var child_process = require('child_process');
+    child_process.exec('npm install', {cwd: __dirname}, function (error) {
+      if (error !== null) {
+        console.log('exec error: ' + error);
+        reject('npm installation failed');
+      }
+      else {
+        resolve();
+      }
+    });
+  });
+};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "cordova-enable-hooks",
+    "version": "1.0.2",
+    "description": "",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "q": "^1.5.1",
+        "plist":"^3.0.1",
+        "xmldom":"^0.4.0"        
+    }
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,16 +6,8 @@ var fs = require("fs");
  * @returns {string} platform version
  */
 function getPlatformVersion(context) {
-    var projectRoot = context.opts.projectRoot;
-    var platformsJsonFile = path.join(
-        projectRoot,
-        "platforms",
-        "platforms.json"
-    );
-    var platforms = require(platformsJsonFile);
     var platform = context.opts.cordova.version;
     return platform;
-    //return platforms[platform];
 }
 
 function rmNonEmptyDir(dir_path) {


### PR DESCRIPTION
Update NPM method to install dependencies for mabs 6.3, removed unused code from util hook and upgraded minsdkversion for mabs 7 compatibility